### PR TITLE
Update move-template-into-script.js

### DIFF
--- a/lib/move-template-into-script.js
+++ b/lib/move-template-into-script.js
@@ -61,7 +61,11 @@ module.exports = function (__sanParts__, config) {
                 return;
             }
 
-            path.node.declaration.properties.push(objectPropertyAst);
+            if (path.node.declaration.type === 'ObjectExpression') {
+                path.node.declaration.properties.push(objectPropertyAst);
+            } else if (path.node.declaration.type === 'CallExpression') {
+                path.node.declaration.arguments[0].properties.push(objectPropertyAst);
+            }
         }
     });
 


### PR DESCRIPTION
解决export不为Object的情况，例如引用san-store的情况：export default connect.san(
    {name: 'user.name'},
    {change: 'changeUserName'}
)({
    initData() {},
    attached() {}
});